### PR TITLE
デフォルトフォントの削除（プライマリフォントの続き）

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -15,12 +15,9 @@
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
 }
 
 body {
   background: var(--background);
   color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,7 +2,7 @@ import Image from "next/image";
 
 export default function Home() {
   return (
-    <div className="grid min-h-screen grid-rows-[20px_1fr_20px] items-center justify-items-center gap-16 p-8 pb-20 font-[family-name:var(--font-geist-sans)] sm:p-20">
+    <div className="grid min-h-screen grid-rows-[20px_1fr_20px] items-center justify-items-center gap-16 p-8 pb-20 sm:p-20">
       <main className="row-start-2 flex flex-col items-center gap-[32px] sm:items-start">
         <Image
           className="dark:invert"
@@ -12,10 +12,10 @@ export default function Home() {
           height={38}
           priority
         />
-        <ol className="list-inside list-decimal text-center font-[family-name:var(--font-geist-mono)] text-sm/6 sm:text-left">
+        <ol className="list-inside list-decimal text-center text-sm/6 sm:text-left">
           <li className="mb-2 tracking-[-.01em]">
             Get started by editing{" "}
-            <code className="rounded bg-black/[.05] px-1 py-0.5 font-[family-name:var(--font-geist-mono)] font-semibold dark:bg-white/[.06]">
+            <code className="rounded bg-black/[.05] px-1 py-0.5 font-semibold dark:bg-white/[.06]">
               app/page.tsx
             </code>
             .


### PR DESCRIPTION
## 概要

<!-- 実装内容 -->

- Next.js デフォルトのフォントの指定を削除しました。

## 参考 URL

<!--
参考にした記事がある場合、そのURL

- URL 1
- URL 2
-->

## セルフチェック

- [x] 外観に大きな違和感がない
- [x] サーバーとクライアント両方のコンソールに新たな警告がない

### 命名

- [x] `data` , `item` などの、非常に抽象的な変数名を使用していない
- [x] 配列の変数名は、複数形または末尾に `list` を付けたものを使用し、配列であることを明示している
- [x] マジックナンバーは定数化している
- [x] 複雑な処理や条件式の結果は「説明変数」化し、変数名を用いて内容を明示している（[参考](https://wb-hp.com/blog/2020/11/09/explanatory-variable.html)）

### 条件分岐

- [x] 比較の条件式は、調査対象を左辺に、比較対象を右辺に記述している（[参考](https://note.shiftinc.jp/n/n3ae20c8ba524)）
- [x] 1 つの値のパターンによって多数に分岐する場合は、 `if` ではなく `switch` を使用している（[参考](https://zenn.dev/remrem/articles/1b42263cdfd47a)）
- [x] 複雑な条件分岐は、「早期リターン」を使用して簡略化している（[参考](https://zenn.dev/media_engine/articles/early_return)）

### JavaScript（命名）

- [x] 変数名、関数名、プロパティ名は、ローワーキャメルケースである
- [x] クラス名はパスカルケースである
- [x] 定数名はスネークケースである

### JavaScript（処理）

- [x] できる限り、 `let` ではなく `const` を使用している（[参考](https://typescriptbook.jp/reference/values-types-variables/let-and-const#let%E3%81%A8const%E3%81%AE%E4%BD%BF%E3%81%84%E5%88%86%E3%81%91)）
- [x] 文字列の結合にはテンプレートリテラルを使用している
- [x] `==(等価演算子)` ではなく `===(厳密等価演算子)` を使用している

### TypeScript（命名）

- [x] インターフェース、タイプは、パスカルケースである（[参考](https://typescript-jp.gitbook.io/deep-dive/styleguide)）

### React

- [x] コンポーネント名はパスカルケースである
- [x] コンポーネントに子要素がない場合は、「自己終了タグ」を使用している
- [x] コンポーネントに `true` を渡す場合は、 `= {true}` を省略している（[参考](https://typescriptbook.jp/reference/jsx#true%E3%81%AE%E5%A0%B4%E5%90%88%E3%81%AF%E7%9C%9F%E5%81%BD%E5%B1%9E%E6%80%A7%E3%82%92%E7%9C%81%E7%95%A5%E3%81%99%E3%82%8B)）
- [x] コンポーネントに文字列を渡す場合は、 `{}` を省略している
- [x] イベントハンドラー等の関数は JSX 外で宣言している

### Next.js

- [x] ESLintを実行し、警告がない

### コメント

- [x] コメントにはアノテーションコメントが付与されている（[参考](https://sqripts.com/2022/04/19/20423/)）
