### PR TITLE
feat: PC画面のヘッダーに横のpaddingを追加しました

### DIFF
--- a/app/ui/header.tsx
+++ b/app/ui/header.tsx
@@ -5,7 +5,7 @@ import { faCircleUser } from "@fortawesome/free-regular-svg-icons";
 export default function Header() {
   return (
     <header className="bg-primary h-18">
-      <div className="mx-auto flex h-full w-9/10 items-center justify-between lg:w-5xl">
+      <div className="mx-auto flex h-full w-9/10 items-center justify-between lg:w-5xl lg:px-4">
         <Link href="/" className="font-bold text-white lg:text-2xl">
           マイクラ募集掲示板
         </Link>


### PR DESCRIPTION
## 概要

<!-- 実装内容 -->

PC画面のヘッダーに横のpaddingを追加しました。

## 参考 URL

<!--
参考にした記事がある場合、そのURL

- URL 1
- URL 2
-->

## セルフチェック

- [x] PCとスマホの両方で、外観に大きな違和感がない
- [x] サーバーとクライアントの両方で、コンソールに新たな警告がない

### 命名

- [x] `data` , `item` などの、非常に抽象的な変数名を使用していない
- [x] 配列の変数名は、複数形または末尾に `list` を付けたものを使用し、配列であることを明示している
- [x] マジックナンバーは定数化している
- [x] 複雑な処理や条件式の結果は「説明変数」化し、変数名を用いて内容を明示している（[参考](https://wb-hp.com/blog/2020/11/09/explanatory-variable.html)）

### 条件分岐

- [x] 比較の条件式は、調査対象を左辺に、比較対象を右辺に記述している（[参考](https://note.shiftinc.jp/n/n3ae20c8ba524)）
- [x] 1 つの値のパターンによって多数に分岐する場合は、 `if` ではなく `switch` を使用している（[参考](https://zenn.dev/remrem/articles/1b42263cdfd47a)）
- [x] 複雑な条件分岐は、「早期リターン」を使用して簡略化している（[参考](https://zenn.dev/media_engine/articles/early_return)）

### JavaScript（命名）

- [x] 変数名、関数名、プロパティ名は、ローワーキャメルケースである
- [x] クラス名はパスカルケースである
- [x] 定数名はスネークケースである

### JavaScript（処理）

- [x] できる限り、 `let` ではなく `const` を使用している（[参考](https://typescriptbook.jp/reference/values-types-variables/let-and-const#let%E3%81%A8const%E3%81%AE%E4%BD%BF%E3%81%84%E5%88%86%E3%81%91)）
- [x] 文字列の結合にはテンプレートリテラルを使用している
- [x] `==(等価演算子)` ではなく `===(厳密等価演算子)` を使用している

### TypeScript（命名）

- [x] インターフェース、タイプは、パスカルケースである（[参考](https://typescript-jp.gitbook.io/deep-dive/styleguide)）

### React

- [x] コンポーネント名はパスカルケースである
- [x] コンポーネントに子要素がない場合は、「自己終了タグ」を使用している
- [x] コンポーネントに `true` を渡す場合は、 `= {true}` を省略している（[参考](https://typescriptbook.jp/reference/jsx#true%E3%81%AE%E5%A0%B4%E5%90%88%E3%81%AF%E7%9C%9F%E5%81%BD%E5%B1%9E%E6%80%A7%E3%82%92%E7%9C%81%E7%95%A5%E3%81%99%E3%82%8B)）
- [x] コンポーネントに文字列を渡す場合は、 `{}` を省略している
- [x] イベントハンドラー等の関数は JSX 外で宣言している

### Next.js

- [x] ESLintを実行し、新たな警告がない

### コメント

- [x] コメントにはアノテーションコメントが付与されている（[参考](https://sqripts.com/2022/04/19/20423/)）
